### PR TITLE
Add Tymeslot — scheduling/appointment booking (Calendly alternative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ The way we organize and manage our tasks has a significant impact on productivit
 - [Planka](https://github.com/plankanban/planka) ★10718 - The realtime kanban board for workgroups built with React and Redux. [JS, GNU Affero General Public License v3.0].
 - [WeKan](https://github.com/wekan/wekan) ★20622 - The Open Source kanban (built with Meteor). Keep variable/table/field names camelCase. For translations, only add Pull Request changes to wekan/i18n/en.i18n.json , other translations are done at https://app.transifex.com/wekan/wekan only. [JS, MIT License].
 
+### Scheduling / Appointment Booking (Calendly alternatives)
+
+Self-hostable alternatives to Calendly and similar scheduling tools, letting individuals and teams share their availability and accept bookings without vendor lock-in.
+
+- [Tymeslot](https://github.com/Tymeslot/tymeslot) ★34 - Open-source meeting scheduling platform. Share your availability and let guests book time with you. [Elixir, Other license].
+
 
 ## Business
 


### PR DESCRIPTION
## What this adds

A new **Scheduling / Appointment Booking** subsection under Collaboration, with [Tymeslot](https://github.com/Tymeslot/tymeslot) as the first entry.

Tymeslot is a self-hostable meeting scheduling platform — an open-source alternative to Calendly — built with Elixir/Phoenix. It is free to use and self-host.

## Notes

- No existing category covered scheduling/appointment booking tools, so I added a new subsection after Kanban board
- Licensed under Elastic License 2.0, listed as "Other license" consistent with other non-OSI entries in this list