### PR TITLE
Add SEO & Google Ads section with toprank

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ More:
 - [Shynet](https://github.com/milesmcc/shynet) ★3131 - Modern, privacy-friendly, and detailed web analytics that works without cookies or JS. [🐍, Apache License 2.0].
 - [Umami](https://github.com/umami-software/umami) ★35907 - Umami is a simple, fast, privacy-focused alternative to Google Analytics. [TS, MIT License].
 
+### SEO & Google Ads (Ahrefs, SEMrush alternatives)
+
+- [toprank](https://github.com/nowork-studio/toprank) ★107 - Open-source Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted ad spend, rewrite meta tags, generate JSON-LD schema markup, and ship fixes to WordPress/Strapi/Contentful/Ghost. Agentic workflow inside Claude Code rather than a dashboard. [Python, MIT License].
+
 ### Static website generator
 
 - [11ty](https://github.com/11ty/eleventy) ★19530 - A simpler site generator. Transforms a directory of templates (of varying types) into HTML. [JS, MIT License].


### PR DESCRIPTION
Proposes a new section under Web for open-source SEO and Google Ads tools, with **toprank** as the first entry.

toprank is an open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. It positions as an alternative to Ahrefs ($79-$2500/mo) and SEMrush ($139+/mo) — connects to Google Search Console, PageSpeed Insights, and the Google Ads API, then ships fixes directly to source code or CMS.

## Why a new section?
The list currently covers Web analytics (Matomo/Plausible/Umami as GA alternatives) but has no category for SEO or paid-ads tooling. These are major SaaS categories with almost no open-source alternatives — and developer indie hackers specifically avoid the $79+/month commercial options.

## Traction
- **107 GitHub stars, 14 forks**
- MIT licensed, actively maintained
- CHANGELOG, unit tests, and LLM-judge eval tests

- Source: https://github.com/nowork-studio/toprank

Happy to restructure the placement (e.g., slot under Business instead of Web) if you prefer — wanted to propose the section since there's nothing equivalent in the list today.