### PR TITLE
Add os-alt to other lists of FOSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ This it not the first list of free / open source software. Here are some other l
 - [Awesome Free Software](https://github.com/johnjago/awesome-free-software) ★2659 - Curated list of free as in freedom software. [Creative Commons Zero v1.0 Universal].
 - [Open-source alternatives](https://opensource.builders/)
 - [PickYourTech](https://www.pickyourtech.com) - Catalog of open-source projects, categorized with detailed metadata and open-source alternatives to popular SaaS platforms.
+- [os-alt](https://code-rho-dun.vercel.app) - Directory of paid SaaS with strictly self-hostable open-source alternatives, listing setup-time score, monthly self-host cost estimate, and migration sketch per tool.
 
 
 ## Other lists


### PR DESCRIPTION
Adds [os-alt](https://code-rho-dun.vercel.app) to the **Other lists of free / open source software** section.

**What it is:** A directory of paid SaaS products (Notion, Slack, Linear, Datadog, etc.) mapped to strictly self-hostable open-source alternatives. Each entry includes:

- A setup-time score (e.g., `5min docker compose` vs `1h manual` vs `needs k8s`)
- A monthly self-host cost estimate (e.g., `$5 VPS handles N users`)
- A short migration sketch (export-from-SaaS → import-to-OSS steps)
- License, language/platform, and last-commit freshness from GitHub

**Why it fits this section:** It's a curated alternative-to-SaaS directory, in the same vein as the existing entries (EuroStack Directory, opensource.builders, PickYourTech, RunaCapital's awesome-oss-alternatives). The differentiator vs. those is the setup/cost/migration metadata per tool.

**Note on URL:** The current production URL is `code-rho-dun.vercel.app` (auto-generated by Vercel). If the PR is held while we move to a custom domain, happy to update before merge.

One-line per [CONTRIBUTING](https://github.com/sfermigier/awesome-foss-alternatives) — appended to the FOSS lists section, no other changes.