### PR TITLE
Add AI Dictation as a voice-dictation alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Self-hostable alternatives to Calendly and similar scheduling tools, letting ind
 - **[Aster Mail](https://github.com/Aster-Privacy/Aster-Mail)** - "Quantum-safe end-to-end encrypted email. Alternative to Gmail, Proton Mail." [AGPL-3.0]
 
 
+## Productivity
+
+### Voice Dictation (Wispr Flow, superwhisper alternatives)
+
+- [AI Dictation](https://github.com/writingmate/aidictation) - Open-source speech-to-text and dictation app for macOS, Windows, iPhone, iPad, and Android, with offline recognition on supported devices and optional cloud transcription and cleanup. [Swift/Kotlin/C#, MIT License].
+
+
 ## Business
 
 ### Invoicing (FreshBooks / QuickBooks alternatives)


### PR DESCRIPTION
## What changed

- Added a small Productivity section for open-source voice-dictation alternatives.
- Added AI Dictation as the first entry.

## Why

AI Dictation is an MIT-licensed alternative to proprietary voice-dictation products and supports current desktop and mobile platforms, which fits this list's practical FOSS-alternatives scope.

## Validation

- Confirmed there is no existing AI Dictation entry, issue, or pull request.
- Checked the platform, processing-mode, language, and license wording against the current project repository.
- Confirmed the project link returns HTTP 200.
- Ran `git diff --check` on the complete change.

## Disclosure

I am affiliated with AI Dictation and am submitting it openly rather than presenting this as an independent recommendation. The contribution was prepared with AI assistance and checked against this repository's current contents and recent accepted contributions.
