### PR TITLE
Add YunCMS to Web CMS alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Platforms for collecting, organizing, and prioritizing customer feedback, featur
 
 - [Wordpress](https://github.com/WordPress/WordPress) ★20984 - WordPress, Git-ified. This repository is just a mirror of the WordPress subversion repository. Please do not send pull requests. Submit pull requests to https://github.com/WordPress/wordpress-develop and patches to https://core.trac.wordpress.org/ instead. [PHP, Other license].
 - [Ghost](https://github.com/TryGhost/Ghost) ★52242 - Independent technology for modern publishing, memberships, subscriptions and newsletters. [JS, MIT License].
-- [YunCMS](https://github.com/Yunsoft-Software/yuncms) ★0 - Self-hosted MySQL CMS and REST backend with a React Studio, RBAC, Files, extensions and optional MCP. [JS, MIT License].
+- [YunCMS](https://github.com/Yunsoft-Software/yuncms) ★0 - Self-hosted MySQL CMS and REST backend with a React Studio, RBAC, Files, extensions and optional MCP. [JS, MIT License]. Website: [Yunsoft](https://yunsoft.com).
 
 More:
 
@@ -291,4 +291,3 @@ This it not the first list of free / open source software. Here are some other l
 ## Other lists
 
 * [IndieStack](https://indiestack.fly.dev/) - Directory of indie-built SaaS alternatives across 100+ categories.
-

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Platforms for collecting, organizing, and prioritizing customer feedback, featur
 
 - [Wordpress](https://github.com/WordPress/WordPress) ★20984 - WordPress, Git-ified. This repository is just a mirror of the WordPress subversion repository. Please do not send pull requests. Submit pull requests to https://github.com/WordPress/wordpress-develop and patches to https://core.trac.wordpress.org/ instead. [PHP, Other license].
 - [Ghost](https://github.com/TryGhost/Ghost) ★52242 - Independent technology for modern publishing, memberships, subscriptions and newsletters. [JS, MIT License].
+- [YunCMS](https://github.com/Yunsoft-Software/yuncms) ★0 - Self-hosted MySQL CMS and REST backend with a React Studio, RBAC, Files, extensions and optional MCP. [JS, MIT License].
 
 More:
 


### PR DESCRIPTION
Adds [YunCMS](https://github.com/Yunsoft-Software/yuncms) to Web CMS and Blog Engines. YunCMS is a public MIT-licensed, self-hosted MySQL CMS and REST backend with a React Studio, RBAC, Files, extensions, and optional MCP.

The entry records the current GitHub star count as 0. The project README documents the current 0.1.x series as pre-stable.

Validation: git diff --check passed.

Disclosure: I am submitting this on behalf of the YunCMS project.